### PR TITLE
Integrate vercel-storage as a backend

### DIFF
--- a/storages/backends/vercel.py
+++ b/storages/backends/vercel.py
@@ -12,28 +12,28 @@ class VercelStorage(BaseStorage):
 
     def _open(self, name, mode='rb'):
         # Open a file from Vercel storage
-        raise NotImplementedError("This method must be overridden.")
+        return blob.open_blob(name, mode)
 
     def _save(self, name, content):
         # Save a file to Vercel storage
-        raise NotImplementedError("This method must be overridden.")
+        return blob.save_blob(name, content)
 
     def delete(self, name):
         # Delete a file from Vercel storage
-        raise NotImplementedError("This method must be overridden.")
+        blob.delete_blob(name)
 
     def exists(self, name):
         # Check if a file exists in Vercel storage
-        raise NotImplementedError("This method must be overridden.")
+        return blob.blob_exists(name)
 
     def listdir(self, path):
         # List directories and files under a path in Vercel storage
-        raise NotImplementedError("This method must be overridden.")
+        return blob.list_blobs(path)
 
     def size(self, name):
         # Get the size of a file in Vercel storage
-        raise NotImplementedError("This method must be overridden.")
+        return blob.get_blob_size(name)
 
     def url(self, name):
         # Get the URL of a file in Vercel storage
-        raise NotImplementedError("This method must be overridden.")
+        return blob.get_blob_url(name)


### PR DESCRIPTION
Related to #1

This pull request integrates `vercel-storage` as a backend in the `django-storages` library, enabling CRUD operations on files stored in Vercel Storage.

- **Implements storage operations**: The `_open`, `_save`, `delete`, `exists`, `listdir`, `size`, and `url` methods in `storages/backends/vercel.py` are now fully implemented. These methods utilize the `blob` module from `storages/backends/vercel_storage/blob.py` to interact with Vercel Storage, allowing for opening, saving, deleting, checking existence, listing directories and files, getting file size, and generating URLs for files stored in Vercel Storage.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/junkei-okinawa/django-storages/issues/1?shareId=d51f3b16-b162-4eaf-8f66-edfd8fef3a21).